### PR TITLE
Popover gefixt

### DIFF
--- a/Umfrage-Tool/Umfrage-Tool/Scripts/Popover.js
+++ b/Umfrage-Tool/Umfrage-Tool/Scripts/Popover.js
@@ -18,12 +18,12 @@
         $('select').popover({
             delay: { show: 700 },
             trigger: 'hover focus',
-            placement: 'top'
+            placement: 'right'
         });
         $('.input-range').popover({
             delay: { show: 700 },
             trigger: 'hover focus',
-            placement: 'top'
+            placement: 'left'
         });
     });
 }


### PR DESCRIPTION
Die Popover wurden oben angezeigt, Select-Popover jetzt rechts und die Skalen-Popover links